### PR TITLE
Add $OU and $CONFDIR variable for more flexibility

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,5 +9,5 @@ build:
   artifacts:
     name: "$CI_PROJECT_NAME-$CI_COMMIT_TAG"
     paths:
-      - build/w2c-letsencrypt-esxi.vib
-      - build/w2c-letsencrypt-esxi-offline-bundle.zip
+      - build/acme-esxi.vib
+      - build/acme-esxi-offline-bundle.zip

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Let's Encrypt for VMware ESXi
 
-`w2c-letsencrypt-esxi` is a lightweight open-source solution to automatically obtain and renew Let's Encrypt or private ACME CA certificates on standalone VMware ESXi servers. Packaged as a _VIB archive_ or _Offline Bundle_, install/upgrade/removal is possible directly via the web UI or, alternatively, with just a few SSH commands.
+`acme-esxi` is a lightweight open-source solution to automatically obtain and renew Let's Encrypt or private ACME CA certificates on standalone VMware ESXi servers. Packaged as a _VIB archive_ or _Offline Bundle_, install/upgrade/removal is possible directly via the web UI or, alternatively, with just a few SSH commands.
 
 Features:
 
@@ -22,7 +22,7 @@ Many ESXi servers are accessible over the Internet and use self-signed X.509 cer
 
 ## Prerequisites
 
-Before installing `w2c-letsencrypt-esxi`, ensure the following preconditions are met:
+Before installing `acme-esxi`, ensure the following preconditions are met:
 
 - Your server is publicly reachable over the Internet
 - A _Fully Qualified Domain Name (FQDN)_ is set in ESXi. Something like `localhost.localdomain` will not work
@@ -33,23 +33,23 @@ Before installing `w2c-letsencrypt-esxi`, ensure the following preconditions are
 
 ## Install
 
-`w2c-letsencrypt-esxi` can be installed via SSH or the Web UI (= Embedded Host Client).
+`acme-esxi` can be installed via SSH or the Web UI (= Embedded Host Client).
 
 ### SSH on ESXi
 
 ```bash
-$ wget -O /tmp/w2c-letsencrypt-esxi.vib https://github.com/w2c/letsencrypt-esxi/releases/latest/download/w2c-letsencrypt-esxi.vib
+$ wget -O /tmp/acme-esxi.vib https://github.com/NateTheSage/acme-esxi/releases/latest/download/acme-esxi.vib
 
-$ esxcli software vib install -v /tmp/w2c-letsencrypt-esxi.vib -f
+$ esxcli software vib install -v /tmp/acme-esxi.vib -f
 Installation Result
    Message: Operation finished successfully.
    Reboot Required: false
-   VIBs Installed: web-wack-creations_bootbank_w2c-letsencrypt-esxi_1.0.0-0.0.0
+   VIBs Installed: web-wack-creations_bootbank_acme-esxi_1.0.0-0.0.0
    VIBs Removed:
    VIBs Skipped:
 
 $ esxcli software vib list | grep w2c
-w2c-letsencrypt-esxi  1.0.0-0.0.0  web-wack-creations  CommunitySupported  2022-05-29
+acme-esxi  1.0.0-0.0.0  web-wack-creations  CommunitySupported  2022-05-29
 
 $ cat /var/log/syslog.log | grep w2c
 2022-05-29T20:01:46Z /etc/init.d/w2c-letsencrypt: Running 'start' action
@@ -60,7 +60,7 @@ $ cat /var/log/syslog.log | grep w2c
 
 ### Web UI (= Embedded Host Client)
 
-1. _Storage -> Datastores:_ Use the Datastore browser to upload the [VIB file](https://github.com/w2c/letsencrypt-esxi/releases/latest/download/w2c-letsencrypt-esxi.vib) to a datastore path of your choice.
+1. _Storage -> Datastores:_ Use the Datastore browser to upload the [VIB file](https://github.com/w2c/letsencrypt-esxi/releases/latest/download/acme-esxi.vib) to a datastore path of your choice.
 2. _Manage -> Security & users:_ Set the acceptance level of your host to _Community_.
 3. _Manage -> Packages:_ Switch to the list of installed packages, click on _Install update_ and enter the absolute path on the datastore where your just uploaded VIB file resides.
 4. While the VIB is installed, ESXi requests a certificate from Let's Encrypt. If you reload the Web UI afterwards, the newly requested certificate should already be active. If not, see the [Wiki](https://github.com/w2c/letsencrypt-esxi/wiki) for troubleshooting.
@@ -91,19 +91,19 @@ To apply your modifications, run `/etc/init.d/w2c-letsencrypt start`
 
 ## Uninstall
 
-Remove the installed `w2c-letsencrypt-esxi` package via SSH:
+Remove the installed `acme-esxi` package via SSH:
 
 ```bash
-$ esxcli software vib remove -n w2c-letsencrypt-esxi
+$ esxcli software vib remove -n acme-esxi
 Removal Result
    Message: Operation finished successfully.
    Reboot Required: false
    VIBs Installed:
-   VIBs Removed: web-wack-creations_bootbank_w2c-letsencrypt-esxi_1.0.0-0.0.0
+   VIBs Removed: web-wack-creations_bootbank_acme-esxi_1.0.0-0.0.0
    VIBs Skipped:
 ```
 
-This action will purge `w2c-letsencrypt-esxi`, undo any changes to system files (cronjob and port redirection) and finally call `/sbin/generate-certificates` to generate and install a new, self-signed certificate.
+This action will purge `acme-esxi`, undo any changes to system files (cronjob and port redirection) and finally call `/sbin/generate-certificates` to generate and install a new, self-signed certificate.
 
 ## Usage
 
@@ -111,7 +111,7 @@ Usually, fully-automated. No interaction required.
 
 ### Hostname Change
 
-If you change the hostname on our ESXi instance, the domain the certificate is issued for will mismatch. In that case, either re-install `w2c-letsencrypt-esxi` or simply run `/etc/init.d/w2c-letsencrypt start`, e.g.:
+If you change the hostname on our ESXi instance, the domain the certificate is issued for will mismatch. In that case, either re-install `acme-esxi` or simply run `/etc/init.d/w2c-letsencrypt start`, e.g.:
 
 ```bash
 $ esxcfg-advcfg -s new-example.com /Misc/hostname
@@ -194,7 +194,7 @@ See the [Wiki](https://github.com/w2c/letsencrypt-esxi/wiki) for possible pitfal
 
 ## License
 
-    w2c-letsencrypt-esxi is free software;
+    acme-esxi is free software;
     you can redistribute it and/or modify it under the terms of the
     GNU General Public License as published by the Free Software Foundation,
     either version 3 of the License, or (at your option) any later version.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ For a non-default (i.e. private CA) configuration, you can also store your confi
 DIRECTORY_URL="https://acme-staging-v02.api.letsencrypt.org/directory"
 # Change your CA bundle if your CA is private, otherwise acme-tiny will complain about untrusted certs.
 SSL_CERT_FILE="$LOCALDIR/ca-certificates.crt"
+# Make sure to also change your OU, default is Let's Encrypt.
+OU="O=Let's Encrypt"
 # Set the renewal interval to 15 days
 RENEW_DAYS=15
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
+*Originally a product of w2c/letsencrypt-esxi. Modified for those of us that are either unable or unwilling to expose our ESXi management interfaces to the Internet.*
+
 # Let's Encrypt for VMware ESXi
 
-`w2c-letsencrypt-esxi` is a lightweight open-source solution to automatically obtain and renew Let's Encrypt certificates on standalone VMware ESXi servers. Packaged as a _VIB archive_ or _Offline Bundle_, install/upgrade/removal is possible directly via the web UI or, alternatively, with just a few SSH commands.
+`w2c-letsencrypt-esxi` is a lightweight open-source solution to automatically obtain and renew Let's Encrypt or private ACME CA certificates on standalone VMware ESXi servers. Packaged as a _VIB archive_ or _Offline Bundle_, install/upgrade/removal is possible directly via the web UI or, alternatively, with just a few SSH commands.
 
 Features:
 
@@ -8,12 +10,15 @@ Features:
 - **Auto-renewal**: A cronjob runs once a week to check if a certificate is due for renewal
 - **Persistent**: The certificate, private key and all settings are preserved over ESXi upgrades
 - **Configurable**: Customizable parameters for renewal interval, Let's Encrypt (ACME) backend, etc
+- **Can be used with any ACME CA**: [LabCA](https://github.com/hakwerk/labca) is a great example.
 
 _Successfully tested with all currently supported versions of ESXi (6.5, 6.7, 7.0)._
 
 ## Why?
 
-Many ESXi servers are accessible over the Internet and use self-signed X.509 certificates for TLS connections. This situation not only leads to annoying warnings in the browser when calling the Web UI, but can also be the reason for serious security problems. Despite the enormous popularity of [Let's Encrypt](https://letsencrypt.org), there is no convenient way to automatically request, renew or remove certificates in ESXi.
+Many ESXi servers are accessible over the Internet and use self-signed X.509 certificates for TLS connections. This situation not only leads to annoying warnings in the browser when calling the Web UI, but can also be the reason for serious security problems. Despite the enormous popularity of [Let's Encrypt](https://letsencrypt.org) and ACME, there is no convenient way to automatically request, renew or remove certificates in ESXi.
+
+*No user should get used to ignoring a certificate warning from any browser, even self-signed or local.*
 
 ## Prerequisites
 
@@ -22,6 +27,7 @@ Before installing `w2c-letsencrypt-esxi`, ensure the following preconditions are
 - Your server is publicly reachable over the Internet
 - A _Fully Qualified Domain Name (FQDN)_ is set in ESXi. Something like `localhost.localdomain` will not work
 - The hostname you specified can be resolved via A and/or AAAA records in the corresponding DNS zone
+- If you're running a private CA, the CA is reachable and you have any certificates you may need bundled.
 
 **Note:** As soon as you install this software, any existing, non Let's Encrypt certificate gets replaced!
 
@@ -65,9 +71,16 @@ If you want to try out the script before putting it into production, you may wan
 
 `vi /opt/w2c-letsencrypt/renew.cfg`
 
+For a non-default (i.e. private CA) configuration, you can also store your config file in `/etc/w2c-letsencrypt` and run `/sbin/auto-backup.sh` to persist your configuration.
+
+`vi /etc/w2c-letsencrypt/renew.cfg`
+`/sbin/auto-backup.sh`
+
 ```bash
-# Request a certificate from the staging environment
+# Request a certificate from the staging environment. This can also be set to a private CA.
 DIRECTORY_URL="https://acme-staging-v02.api.letsencrypt.org/directory"
+# Change your CA bundle if your CA is private, otherwise acme-tiny will complain about untrusted certs.
+SSL_CERT_FILE="$LOCALDIR/ca-certificates.crt"
 # Set the renewal interval to 15 days
 RENEW_DAYS=15
 ```

--- a/acme-esxi
+++ b/acme-esxi
@@ -4,7 +4,7 @@
 # Released under the GNU GPLv3 License.
 #
 # chkconfig: on 99 99
-# description: Letsencrypt for ESXi
+# description: ACME and Let's Encrypt for ESXi
 #
 
 export PATH=/sbin:/usr/sbin:/bin:/usr/bin
@@ -19,11 +19,11 @@ for action in "$@"; do
 
    case "$action" in
       start)
-         /opt/w2c-letsencrypt/renew.sh
+         /opt/acme-esxi/renew.sh
          ;;
 
       remove)
-         sed -i '/\/opt\/w2c-letsencrypt/d' /var/spool/cron/crontabs/root
+         sed -i '/\/opt\/acme-esxi/d' /var/spool/cron/crontabs/root
          sed -i '/acme-challenge/d' /etc/vmware/rhttpproxy/endpoints.conf
          /sbin/generate-certificates
          for s in /etc/init.d/*; do if $s | grep ssl_reset > /dev/null; then $s ssl_reset; fi; done

--- a/acme_dns_tiny.py
+++ b/acme_dns_tiny.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+# pylint: disable=multiple-imports
+"""ACME client to met DNS challenge and receive TLS certificate"""
+import argparse, base64, binascii, configparser, copy, hashlib, ipaddress, json, logging
+import re, sys, subprocess, time
+import requests
+import dns.exception, dns.query, dns.name, dns.resolver, dns.rrset, dns.tsigkeyring, dns.update
+
+LOGGER = logging.getLogger('acme_dns_tiny')
+LOGGER.addHandler(logging.StreamHandler())
+
+
+def _base64(text):
+    """Encodes string as base64 as specified in the ACME RFC."""
+    return base64.urlsafe_b64encode(text).decode("utf8").rstrip("=")
+
+
+def _openssl(command, options, communicate=None):
+    """Run openssl command line and raise IOError on non-zero return."""
+    openssl = subprocess.Popen(["openssl", command] + options,
+                               stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE)
+    out, err = openssl.communicate(communicate)
+    if openssl.returncode != 0:
+        raise IOError("OpenSSL Error: {0}".format(err))
+    return out
+
+
+# pylint: disable=too-many-locals,too-many-branches,too-many-statements
+def get_crt(config, log=LOGGER):
+    """Get ACME certificate by resolving DNS challenge."""
+
+    def _update_dns(rrset, action, resolver):
+        """Updates DNS resource by adding or deleting resource."""
+        algorithm = dns.name.from_text("{0}".format(config["TSIGKeyring"]["Algorithm"].lower()))
+        dns_update = dns.update.Update(config["DNS"]["zone"],
+                                       keyring=private_keyring, keyalgorithm=algorithm)
+        if action == "add":
+            dns_update.add(rrset.name, rrset)
+        elif action == "delete":
+            dns_update.delete(rrset.name, rrset)
+        # Try each IP address found for the configured DNS Host to apply the DNS resource update
+        response = None
+        for nameserver in resolver.nameservers:
+            try:
+                response = dns.query.tcp(dns_update, nameserver,
+                                         port=config.getint("DNS", "Port"))
+            # pylint: disable=broad-except
+            except Exception as exception:
+                log.debug("Unable to %s DNS resource on server with IP %s, try again with "
+                          "next available IP. Error detail: %s", action, nameserver, exception)
+                response = None
+            if response is not None:
+                break
+        if response is None:
+            raise RuntimeError("Unable to {0} DNS resource to {1}".format(action, rrset.name))
+        return response
+
+    def _send_signed_request(url, payload, extra_headers=None):
+        """Sends signed requests to ACME server."""
+        nonlocal nonce
+        if payload == "":  # on POST-as-GET, final payload has to be just empty string
+            payload64 = ""
+        else:
+            payload64 = _base64(json.dumps(payload).encode("utf8"))
+        protected = copy.deepcopy(private_acme_signature)
+        protected["nonce"] = nonce or requests.get(acme_config["newNonce"]).headers['Replay-Nonce']
+        del nonce
+        protected["url"] = url
+        if url == acme_config["newAccount"]:
+            if "kid" in protected:
+                del protected["kid"]
+        else:
+            del protected["jwk"]
+        protected64 = _base64(json.dumps(protected).encode("utf8"))
+        signature = _openssl("dgst", ["-sha256", "-sign", config["acmednstiny"]["AccountKeyFile"]],
+                             "{0}.{1}".format(protected64, payload64).encode("utf8"))
+        jose = {
+            "protected": protected64, "payload": payload64, "signature": _base64(signature)
+        }
+        joseheaders = {'Content-Type': 'application/jose+json'}
+        joseheaders.update(adtheaders)
+        joseheaders.update(extra_headers or {})
+        try:
+            response = requests.post(url, json=jose, headers=joseheaders)
+        except requests.exceptions.RequestException as error:
+            response = error.response
+        if response:
+            nonce = response.headers['Replay-Nonce']
+            try:
+                return response, response.json()
+            except ValueError:  # if body is empty or not JSON formatted
+                return response, json.loads("{}")
+        else:
+            raise RuntimeError("Unable to get response from ACME server.")
+
+    # main code
+    adtheaders = {'User-Agent': 'acme-dns-tiny/2.4',
+                  'Accept-Language': config["acmednstiny"].get("Language", "en")}
+    nonce = None
+
+    log.info("Find domains to validate from the Certificate Signing Request (CSR) file.")
+    csr = _openssl("req", ["-in", config["acmednstiny"]["CSRFile"],
+                           "-noout", "-text"]).decode("utf8")
+    domains = set()
+    common_name = re.search(r"Subject:.*?\s+?CN\s*?=\s*?([^\s,;/]+)", csr)
+    if common_name is not None:
+        domains.add(common_name.group(1))
+    subject_alt_names = re.search(
+        r"X509v3 Subject Alternative Name: (?:critical)?\s+([^\r\n]+)\r?\n",
+        csr, re.MULTILINE)
+    if subject_alt_names is not None:
+        for san in subject_alt_names.group(1).split(", "):
+            if san.startswith("DNS:"):
+                domains.add(san[4:])
+    if len(domains) == 0:  # pylint: disable=len-as-condition
+        raise ValueError("Didn't find any domain to validate in the provided CSR.")
+
+    log.info("Configure DNS client tools.")
+    # That keyring is used to authenticate with the DNS server, it needs to be safely kept
+    private_keyring = dns.tsigkeyring.from_text({config["TSIGKeyring"]["KeyName"]:
+                                                 config["TSIGKeyring"]["KeyValue"]})
+    resolver = dns.resolver.Resolver(configure=False)
+    resolver.retry_servfail = True
+    nameserver = []
+    try:
+        ipaddress.ip_address(config["DNS"]["Host"])
+        nameserver.append(config["DNS"]["Host"])
+    except ValueError:
+        log.debug("  - Configured DNS Host value is not a valid IP address, "
+                  "try to resolve IP address by requesting system DNS servers.")
+        try:
+            nameserver += [ipv6_rrset.to_text() for ipv6_rrset
+                           in dns.resolver.query(config["DNS"]["Host"], rdtype="AAAA")]
+        except dns.exception.DNSException:
+            log.debug(("  - IPv6 addresses not found for the configured DNS Host."))
+        try:
+            nameserver += [ipv4_rrset.to_text() for ipv4_rrset
+                           in dns.resolver.query(config["DNS"]["Host"], rdtype="A")]
+        except dns.exception.DNSException:
+            log.debug("  - IPv4 addresses not found for the configured DNS Host.")
+    if not nameserver:
+        raise ValueError("Unable to resolve any IP address for the configured DNS Host name")
+    resolver.nameservers = nameserver
+
+    log.info("Get private signature from account key.")
+    accountkey = _openssl("rsa", ["-in", config["acmednstiny"]["AccountKeyFile"],
+                                  "-noout", "-text"])
+    signature_search = re.search(r"modulus:\s+?00:([a-f0-9\:\s]+?)\r?\npublicExponent: ([0-9]+)",
+                                 accountkey.decode("utf8"), re.MULTILINE)
+    if signature_search is None:
+        raise ValueError("Unable to retrieve private signature.")
+    pub_hex, pub_exp = signature_search.groups()
+    pub_exp = "{0:x}".format(int(pub_exp))
+    pub_exp = "0{0}".format(pub_exp) if len(pub_exp) % 2 else pub_exp
+    # That signature is used to authenticate with the ACME server, it needs to be safely kept
+    private_acme_signature = {
+        "alg": "RS256",
+        "jwk": {
+            "e": _base64(binascii.unhexlify(pub_exp.encode("utf-8"))),
+            "kty": "RSA",
+            "n": _base64(binascii.unhexlify(re.sub(r"(\s|:)", "", pub_hex).encode("utf-8"))),
+        },
+    }
+    private_jwk = json.dumps(private_acme_signature["jwk"], sort_keys=True, separators=(",", ":"))
+    jwk_thumbprint = _base64(hashlib.sha256(private_jwk.encode("utf8")).digest())
+
+    log.info("Fetch ACME server configuration from the its directory URL.")
+    acme_config = requests.get(config["acmednstiny"]["ACMEDirectory"], headers=adtheaders).json()
+    terms_service = acme_config.get("meta", {}).get("termsOfService", "")
+
+    log.info("Register ACME Account to get the account identifier.")
+    account_request = {}
+    if terms_service:
+        account_request["termsOfServiceAgreed"] = True
+        log.warning(("Terms of service exist and will be automatically agreed if possible, "
+                     "you should read them: %s"), terms_service)
+    account_request["contact"] = config["acmednstiny"].get("Contacts", "").split(';')
+    if account_request["contact"] == [""]:
+        del account_request["contact"]
+
+    http_response, account_info = _send_signed_request(acme_config["newAccount"], account_request)
+    if http_response.status_code == 201:
+        private_acme_signature["kid"] = http_response.headers['Location']
+        log.info("  - Registered a new account: '%s'", private_acme_signature["kid"])
+    elif http_response.status_code == 200:
+        private_acme_signature["kid"] = http_response.headers['Location']
+        log.debug("  - Account is already registered: '%s'", private_acme_signature["kid"])
+
+        http_response, account_info = _send_signed_request(private_acme_signature["kid"], "")
+    else:
+        raise ValueError("Error registering account: {0} {1}"
+                         .format(http_response.status_code, account_info))
+
+    log.info("Update contact information if needed.")
+    if ("contact" in account_request
+            and set(account_request["contact"]) != set(account_info["contact"])):
+        http_response, result = _send_signed_request(private_acme_signature["kid"],
+                                                     account_request)
+        if http_response.status_code == 200:
+            log.debug("  - Account updated with latest contact informations.")
+        else:
+            raise ValueError("Error registering updates for the account: {0} {1}"
+                             .format(http_response.status_code, result))
+
+    # new order
+    log.info("Request to the ACME server an order to validate domains.")
+    new_order = {"identifiers": [{"type": "dns", "value": domain} for domain in domains]}
+    http_response, order = _send_signed_request(acme_config["newOrder"], new_order)
+    if http_response.status_code == 201:
+        order_location = http_response.headers['Location']
+        log.debug("  - Order received: %s", order_location)
+        if order["status"] != "pending" and order["status"] != "ready":
+            raise ValueError("Order status is neither pending neither ready, we can't use it: {0}"
+                             .format(order))
+    elif (http_response.status_code == 403
+          and order["type"] == "urn:ietf:params:acme:error:userActionRequired"):
+        raise ValueError(("Order creation failed ({0}). Read Terms of Service ({1}), then follow "
+                          "your CA instructions: {2}")
+                         .format(order["detail"],
+                                 http_response.headers['Link'], order["instance"]))
+    else:
+        raise ValueError("Error getting new Order: {0} {1}"
+                         .format(http_response.status_code, order))
+
+    # complete each authorization challenge
+    for authz in order["authorizations"]:
+        if order["status"] == "ready":
+            log.info("No challenge to process: order is already ready.")
+            break
+
+        log.info("Process challenge for authorization: %s", authz)
+        # get new challenge
+        http_response, authorization = _send_signed_request(authz, "")
+        if http_response.status_code != 200:
+            raise ValueError("Error fetching challenges: {0} {1}"
+                             .format(http_response.status_code, authorization))
+        domain = authorization["identifier"]["value"]
+
+        if authorization["status"] == "valid":
+            log.info("Skip authorization for domain %s: this is already validated", domain)
+            continue
+        if authorization["status"] != "pending":
+            raise ValueError("Authorization for the domain {0} can't be validated: "
+                             "the authorization is {1}.".format(domain, authorization["status"]))
+
+        challenges = [c for c in authorization["challenges"] if c["type"] == "dns-01"]
+        if not challenges:
+            raise ValueError("Unable to find a DNS challenge to resolve for domain {0}"
+                             .format(domain))
+        log.info("Install DNS TXT resource for domain: %s", domain)
+        challenge = challenges[0]
+        keyauthorization = challenge["token"] + "." + jwk_thumbprint
+        keydigest64 = _base64(hashlib.sha256(keyauthorization.encode("utf8")).digest())
+        dnsrr_domain = "_acme-challenge.{0}.".format(domain)
+        try:  # a CNAME resource can be used for advanced TSIG configuration
+            # Note: the CNAME target has to be of "non-CNAME" type (recursion isn't managed)
+            dnsrr_domain = [response.to_text() for response
+                            in resolver.query(dnsrr_domain, rdtype="CNAME")][0]
+            log.info("  - A CNAME resource has been found for this domain, will install TXT on %s",
+                     dnsrr_domain)
+        except dns.exception.DNSException as dnsexception:
+            log.debug(("  - No CNAME resource has been found for this domain (%s), will "
+                       "install TXT directly on %s"), type(dnsexception).__name__, dnsrr_domain)
+        dnsrr_set = dns.rrset.from_text(dnsrr_domain, config["DNS"].getint("TTL"),
+                                        "IN", "TXT", '"{0}"'.format(keydigest64))
+        try:
+            _update_dns(dnsrr_set, "add", resolver)
+        except dns.exception.DNSException as exception:
+            raise ValueError("Error updating DNS records: {0} : {1}"
+                             .format(type(exception).__name__, str(exception))) from exception
+
+        log.info("Wait for 1 TTL (%s seconds) to ensure DNS cache is cleared.",
+                 config["DNS"].getint("TTL"))
+        time.sleep(config["DNS"].getint("TTL"))
+        challenge_verified = False
+        number_check_fail = 1
+        while challenge_verified is False:
+            try:
+                log.debug(('Self test (try: %s): Check resource with value "%s" exits on '
+                           'nameservers: %s'), number_check_fail, keydigest64,
+                          resolver.nameservers)
+                for response in resolver.query(dnsrr_domain, rdtype="TXT").rrset:
+                    log.debug("  - Found value %s", response.to_text())
+                    challenge_verified = (challenge_verified
+                                          or response.to_text() == '"{0}"'.format(keydigest64))
+            except dns.exception.DNSException as dnsexception:
+                log.debug(
+                    "  - Will retry as a DNS error occurred while checking challenge: %s : %s",
+                    type(dnsexception).__name__, dnsexception)
+            finally:
+                if challenge_verified is False:
+                    if number_check_fail >= 10:
+                        raise ValueError("Error checking challenge, value not found: {0}"
+                                         .format(keydigest64))
+                    number_check_fail = number_check_fail + 1
+                    time.sleep(config["DNS"].getint("TTL"))
+
+        log.info("Asking ACME server to validate challenge.")
+        http_response, result = _send_signed_request(challenge["url"], {})
+        if http_response.status_code != 200:
+            raise ValueError("Error triggering challenge: {0} {1}"
+                             .format(http_response.status_code, result))
+        try:
+            while True:
+                http_response, challenge_status = _send_signed_request(challenge["url"], "")
+                if http_response.status_code != 200:
+                    raise ValueError("Error during challenge validation: {0} {1}".format(
+                        http_response.status_code, challenge_status))
+                if challenge_status["status"] == "pending":
+                    time.sleep(2)
+                elif challenge_status["status"] == "valid":
+                    log.info("ACME has verified challenge for domain: %s", domain)
+                    break
+                else:
+                    raise ValueError("Challenge for domain {0} did not pass: {1}".format(
+                        domain, challenge_status))
+        finally:
+            _update_dns(dnsrr_set, "delete", resolver)
+
+    log.info("Request to finalize the order (all challenges have been completed)")
+    csr_der = _base64(_openssl("req", ["-in", config["acmednstiny"]["CSRFile"],
+                                       "-outform", "DER"]))
+    http_response, result = _send_signed_request(order["finalize"], {"csr": csr_der})
+    if http_response.status_code != 200:
+        raise ValueError("Error while sending the CSR: {0} {1}"
+                         .format(http_response.status_code, result))
+
+    while True:
+        http_response, order = _send_signed_request(order_location, "")
+
+        if order["status"] == "processing":
+            try:
+                time.sleep(float(http_response.headers["Retry-After"]))
+            except (OverflowError, ValueError, TypeError):
+                time.sleep(2)
+        elif order["status"] == "valid":
+            log.info("Order finalized!")
+            break
+        else:
+            raise ValueError("Finalizing order {0} got errors: {1}".format(
+                order_location, order))
+
+    http_response, result = _send_signed_request(
+        order["certificate"], "",
+        {'Accept': config["acmednstiny"].get("CertificateFormat",
+                                             'application/pem-certificate-chain')})
+    if http_response.status_code != 200:
+        raise ValueError("Finalizing order {0} got errors: {1}"
+                         .format(http_response.status_code, result))
+
+    if 'link' in http_response.headers:
+        log.info("  - Certificate links given by server: %s", http_response.headers['link'])
+
+    log.info("Certificate signed and chain received: %s", order["certificate"])
+    return http_response.text
+
+
+def main(argv):
+    """Parse arguments and get certificate."""
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="Tiny ACME client to get TLS certificate by responding to DNS challenges.",
+        epilog="""As the script requires access to your private ACME account key and dns server,
+so PLEASE READ THROUGH IT (it won't take too long, it's a one-file script) !
+
+Example: requests certificate chain and store it in chain.crt
+  python3 acme_dns_tiny.py ./example.ini > chain.crt
+
+See example.ini file to configure correctly this script."""
+    )
+    parser.add_argument("--quiet", action="store_const", const=logging.ERROR,
+                        help="show only errors on stderr")
+    parser.add_argument("--verbose", action="store_const", const=logging.DEBUG,
+                        help="show all debug informations on stderr")
+    parser.add_argument("--csr",
+                        help="specifies CSR file path to use instead of the CSRFile option \
+from the configuration file.")
+    parser.add_argument("configfile", help="path to your configuration file")
+    args = parser.parse_args(argv)
+
+    config = configparser.ConfigParser()
+    config.read_dict({
+        "acmednstiny": {"ACMEDirectory": "https://acme-staging-v02.api.letsencrypt.org/directory"},
+        "DNS": {"Port": 53, "TTL": 10}})
+    config.read(args.configfile)
+
+    if args.csr:
+        config.set("acmednstiny", "csrfile", args.csr)
+
+    if (set(["accountkeyfile", "csrfile", "acmedirectory"]) - set(config.options("acmednstiny"))
+            or set(["keyname", "keyvalue", "algorithm"]) - set(config.options("TSIGKeyring"))
+            or set(["zone", "host", "port", "ttl"]) - set(config.options("DNS"))):
+        raise ValueError("Some required settings are missing.")
+
+    LOGGER.setLevel(args.verbose or args.quiet or logging.INFO)
+    signed_crt = get_crt(config, LOGGER)
+    sys.stdout.write(signed_crt)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main(sys.argv[1:])

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,9 +1,9 @@
 FROM lamw/vibauthor
 
 # Copy all files to the container
-COPY . letsencrypt-esxi
+COPY . acme-esxi
 
 # Run VIB build script
-RUN /bin/bash letsencrypt-esxi/build/create_vib.sh
+RUN /bin/bash acme-esxi/build/create_vib.sh
 
 CMD ["/bin/bash"]

--- a/build/README.md
+++ b/build/README.md
@@ -1,4 +1,4 @@
-# Build w2c-letsencrypt-esxi VIB & Offline Bundle
+# Build acme-esxi VIB & Offline Bundle
 
 The `build.sh` bash script includes the commands needed to generate the VIB and Offline Bundle files. It relies on the [lamw/vibauthor](https://hub.docker.com/r/lamw/vibauthor/) Docker container and uses the files in this repository.
 
@@ -9,37 +9,37 @@ Here is a sample output of the script:
 ```bash
 /bin/bash ./build.sh
 
-Untagged: letsencrypt-esxi:latest
+Untagged: acme-esxi:latest
 Deleted: sha256:3009ff3662db9c3b60157bc0fff1a0c936ec6e301103c5efc50eca113c744b5f
 Deleted: sha256:daff819de772ed33d7de07701d8235453872365586a49c503f5194555424cda1
 Deleted: sha256:e0f946d4136a08d7d87bbce58af17226b019cbd97f3fec018861f155ded84257
 Sending build context to Docker daemon  1.261MB
 Step 1/4 : FROM lamw/vibauthor
  ---> a673ffe4ba43
-Step 2/4 : COPY . letsencrypt-esxi
+Step 2/4 : COPY . acme-esxi
  ---> 6197d7c06029
-Step 3/4 : RUN /bin/bash letsencrypt-esxi/build/create_vib.sh
+Step 3/4 : RUN /bin/bash acme-esxi/build/create_vib.sh
  ---> Running in 3f6f149cfed4
 WARNING: extensibility rules check failed, but was ignored because of --force.
-VIB (web-wack-creations_bootbank_w2c-letsencrypt-esxi_1.0.0-0.0.0) failed a check of extensibility rules for acceptance level 'community': [u'(line 23: col 0) Element vib failed to validate content'].
-Successfully created w2c-letsencrypt-esxi.vib.
-Successfully created w2c-letsencrypt-esxi-offline-bundle.zip.
-**** Info for VIB: w2c-letsencrypt-esxi.vib ****
+VIB (natethesage_bootbank_acme-esxi_1.0.0-0.0.0) failed a check of extensibility rules for acceptance level 'community': [u'(line 23: col 0) Element vib failed to validate content'].
+Successfully created acme-esxi.vib.
+Successfully created acme-esxi-offline-bundle.zip.
+**** Info for VIB: acme-esxi.vib ****
 VIB Format:             2.0.0
-VIB ID:                 web-wack-creations_bootbank_w2c-letsencrypt-esxi_1.0.0-0.0.0
+VIB ID:                 natethesage_bootbank_acme-esxi_1.0.0-0.0.0
 VIB Type:               bootbank
-Name:                   w2c-letsencrypt-esxi
+Name:                   acme-esxi
 Version:                1.0.0-0.0.0
-Vendor:                 web-wack-creations
-Summary:                [Fling] Let's Encrypt for ESXi
-Description:            Let's Encrypt for ESXi
+Vendor:                 natethesage
+Summary:                ACME and Let's Encrypt for ESXi
+Description:            ACME and Let's Encrypt for ESXi
 Creation Date:          2022-05-29 15:03:02+00:00
 Provides:
-        w2c-letsencrypt-esxi = 1.0.0-0.0.0
+        acme-esxi = 1.0.0-0.0.0
 Depends:
 Conflicts:
 Replaces:
-        w2c-letsencrypt-esxi << 1.0.0-0.0.0
+        acme-esxi << 1.0.0-0.0.0
 Software Tags:          []
 MaintenanceMode:        remove/update: False, installation: False
 Signed:                 False
@@ -60,7 +60,7 @@ Step 4/4 : CMD ["/bin/bash"]
 Removing intermediate container fc567d964e69
  ---> 5c3b069e2f7a
 Successfully built 5c3b069e2f7a
-Successfully tagged letsencrypt-esxi:latest
+Successfully tagged acme-esxi:latest
 ```
 
 Upon success, there should be a new directory named `artifacts` which contains the resulting VIB and Offline Bundle files.
@@ -68,22 +68,15 @@ Upon success, there should be a new directory named `artifacts` which contains t
 ```bash
 ls -l ../artifacts
 
--rw-r--r-- 1 root root 30K May 29 15:04 w2c-letsencrypt-esxi-offline-bundle.zip
--rw-r--r-- 1 root root 28K May 29 15:04 w2c-letsencrypt-esxi.vib
+-rw-r--r-- 1 root root 30K May 29 15:04 acme-esxi-offline-bundle.zip
+-rw-r--r-- 1 root root 28K May 29 15:04 acme-esxi.vib
 ```
 
 ## Possible Pitfalls
 
 As the [lamw/vibauthor](https://hub.docker.com/r/lamw/vibauthor/) container builds on CentOS 6, Docker requires a specific `vsyscall` setting to be set in the kernel of the host system that might no longer be the case if a more recent Linux kernel is used. E.g., on a recent version of Debian, running the container will result in a SegFault due to [bug 852620](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=852620). If you encounter this problem, it can be [fixed](https://salsa.debian.org/kernel-team/linux/commit/74f87b226a1267b837d98a5d46824f9b5629962e) by setting `vsyscall=emulate`:
 
-`vi /etc/default/grub`
-
 ```bash
 GRUB_CMDLINE_LINUX_DEFAULT="quiet vsyscall=emulate"
 ```
-
-```bash
-update-grub
-reboot
-```
-Anything past Debian `stretch` appears to need this set.
+I can confirm adding the above line to Debian Bullseye makes the build process work, and it appears anything past Stretch needs this set. YMMV depending on your favorite Linux flavor.

--- a/build/README.md
+++ b/build/README.md
@@ -86,3 +86,4 @@ GRUB_CMDLINE_LINUX_DEFAULT="quiet vsyscall=emulate"
 update-grub
 reboot
 ```
+Anything past Debian `stretch` appears to need this set.

--- a/build/build.sh
+++ b/build/build.sh
@@ -2,14 +2,14 @@
 #
 # Copyright (c) Johannes Feichtner <johannes@web-wack.at>
 #
-# Script to build letsencrypt-esxi VIB using VIB Author
+# Script to build acme-esxi VIB using VIB Author
 
 LOCALDIR=$(dirname "$(readlink -f "$0")")
 cd "${LOCALDIR}/.." || exit
 
-docker rmi -f letsencrypt-esxi 2> /dev/null
+docker rmi -f acme-esxi 2> /dev/null
 rm -rf artifacts
-docker build -t letsencrypt-esxi -f build/Dockerfile .
-docker run -i -v "${PWD}"/artifacts:/artifacts letsencrypt-esxi sh << COMMANDS
-cp letsencrypt-esxi/build/w2c-letsencrypt-esxi* /artifacts
+docker build -t acme-esxi -f build/Dockerfile .
+docker run -i -v "${PWD}"/artifacts:/artifacts acme-esxi sh << COMMANDS
+cp acme-esxi/build/acme-esxi* /artifacts
 COMMANDS

--- a/build/create_vib.sh
+++ b/build/create_vib.sh
@@ -2,10 +2,10 @@
 #
 # Copyright (c) Johannes Feichtner <johannes@web-wack.at>
 #
-# Script to build letsencrypt-esxi VIB using VIB Author
+# Script to build acme-esxi VIB using VIB Author
 
 LOCALDIR=$(dirname "$(readlink -f "$0")")
-TEMP_DIR=/tmp/letsencrypt-esxi-$$
+TEMP_DIR=/tmp/acme-esxi-$$
 
 # Ensure prerequisites are installed
 git version > /dev/null 2>&1
@@ -30,23 +30,23 @@ VIB_TAG=$(git describe --tags --abbrev=0 --match '[0-9]*.[0-9]*.[0-9]*' 2> /dev/
 VIB_DESC_FILE=${TEMP_DIR}/descriptor.xml
 VIB_PAYLOAD_DIR=${TEMP_DIR}/payloads/payload1
 
-# Create letsencrypt-esxi temp dir
+# Create acme-esxi temp dir
 mkdir -p ${TEMP_DIR}
 # Create VIB spec payload directory
 mkdir -p ${VIB_PAYLOAD_DIR}
 
-# Create letsencrypt-esxi VIB descriptor.xml
+# Create acme-esxi VIB descriptor.xml
 cat > ${VIB_DESC_FILE} << __W2C__
 <vib version="5.0">
   <type>bootbank</type>
-  <name>w2c-letsencrypt-esxi</name>
+  <name>acme-esxi</name>
   <version>${VIB_TAG}-0.0.0</version>
-  <vendor>web-wack-creations</vendor>
-  <summary>Let's Encrypt for ESXi</summary>
-  <description>Let's Encrypt for ESXi</description>
+  <vendor>natethesage</vendor>
+  <summary>ACME and Let's Encrypt for ESXi</summary>
+  <description>ACME and Let's Encrypt for ESXi</description>
   <release-date>${VIB_DATE}</release-date>
   <urls>
-    <url key="letsencrypt-esxi">https://github.com/w2c/letsencrypt-esxi</url>
+    <url key="acme-esxi">https://github.com/NateTheSage/acme-esxi</url>
   </urls>
   <relationships>
     <depends/>
@@ -74,22 +74,22 @@ cat > ${VIB_DESC_FILE} << __W2C__
 __W2C__
 
 # Create target directory
-BIN_DIR=${VIB_PAYLOAD_DIR}/opt/w2c-letsencrypt
+BIN_DIR=${VIB_PAYLOAD_DIR}/opt/acme-esxi
 INIT_DIR=${VIB_PAYLOAD_DIR}/etc/init.d
 mkdir -p ${BIN_DIR} ${INIT_DIR}
 
 # Copy files to the corresponding locations
 cp ../* ${BIN_DIR} 2>/dev/null
-cp ../w2c-letsencrypt ${INIT_DIR}
+cp ../acme-esxi ${INIT_DIR}
 
 # Ensure that shell scripts are executable
-chmod +x ${INIT_DIR}/w2c-letsencrypt ${BIN_DIR}/renew.sh
+chmod +x ${INIT_DIR}/acme-esxi ${BIN_DIR}/renew.sh
 
-# Create letsencrypt-esxi VIB + offline bundle
-vibauthor -C -t ${TEMP_DIR} -v w2c-letsencrypt-esxi.vib -O w2c-letsencrypt-esxi-offline-bundle.zip -f
+# Create acme-esxi VIB + offline bundle
+vibauthor -C -t ${TEMP_DIR} -v acme-esxi.vib -O acme-esxi-offline-bundle.zip -f
 
 # Show some details about what we have just created
-vibauthor -i -v w2c-letsencrypt-esxi.vib
+vibauthor -i -v acme-esxi.vib
 
-# Remove letsencrypt-esxi temp dir
+# Remove acme-esxi temp dir
 rm -rf ${TEMP_DIR}

--- a/renew.sh
+++ b/renew.sh
@@ -7,7 +7,7 @@ DOMAIN=$(grep "adv/Misc/HostName" /etc/vmware/esx.conf | awk '{print $3}' | xarg
 LOCALDIR=$(dirname "$(readlink -f "$0")")
 LOCALSCRIPT=$(basename "$0")
 
-CONFDIR="/etc/w2c-letsencrypt"
+CONFDIR="/etc/acme-esxi"
 ACMEDIR="$LOCALDIR/.well-known/acme-challenge"
 DIRECTORY_URL="https://acme-v02.api.letsencrypt.org/directory"
 SSL_CERT_FILE="$LOCALDIR/ca-certificates.crt"

--- a/renew.sh
+++ b/renew.sh
@@ -7,10 +7,12 @@ DOMAIN=$(grep "adv/Misc/HostName" /etc/vmware/esx.conf | awk '{print $3}' | xarg
 LOCALDIR=$(dirname "$(readlink -f "$0")")
 LOCALSCRIPT=$(basename "$0")
 
+CONFDIR="/etc/w2c-letsencrypt"
 ACMEDIR="$LOCALDIR/.well-known/acme-challenge"
 DIRECTORY_URL="https://acme-v02.api.letsencrypt.org/directory"
 SSL_CERT_FILE="$LOCALDIR/ca-certificates.crt"
 RENEW_DAYS=30
+OU="O=Let's Encrypt"
 
 ACCOUNTKEY="esxi_account.key"
 KEY="esxi.key"
@@ -21,6 +23,10 @@ VMWARE_KEY="/etc/vmware/ssl/rui.key"
 
 if [ -r "$LOCALDIR/renew.cfg" ]; then
   . "$LOCALDIR/renew.cfg"
+fi
+
+if [ -r "$CONFDIR/renew.cfg" ]; then
+  . "$CONFDIR/renew.cfg"
 fi
 
 log() {
@@ -49,8 +55,8 @@ if [ -e "$VMWARE_CRT" ]; then
   SAN=$(openssl x509 -in "$VMWARE_CRT" -text -noout | grep DNS: | sed 's/DNS://g' | xargs)
   if [ "$SAN" != "$DOMAIN" ] ; then
     log "Existing cert issued for ${SAN} but current domain name is ${DOMAIN}. Requesting a new one!"
-  # If the cert is issued by Let's Encrypt, check its expiration date, otherwise request a new one
-  elif openssl x509 -in "$VMWARE_CRT" -issuer -noout | grep -q "O=Let's Encrypt"; then
+  # If the cert is issued by Let's Encrypt or a private CA, check its expiration date, otherwise request a new one
+  elif openssl x509 -in "$VMWARE_CRT" -issuer -noout | grep -q "$OU"; then
     CERT_VALID=$(openssl x509 -enddate -noout -in "$VMWARE_CRT" | cut -d= -f2-)
     log "Existing Let's Encrypt cert valid until: ${CERT_VALID}"
     if openssl x509 -checkend $((RENEW_DAYS * 86400)) -noout -in "$VMWARE_CRT"; then


### PR DESCRIPTION
Added a couple of variables for flexibility with both offline CAs (a la LabCA) and needing to persist a configuration file.

Should address #3, in addition to another issue I noticed of the script always reissuing a cert because my OU obviously doesn't match "Let's Encrypt".